### PR TITLE
Integrated Spotify Web API using OAuth 2.0 and making top artist call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+BandMate/Keys.plist

--- a/BandMate.xcodeproj/project.pbxproj
+++ b/BandMate.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		268BF953286EACC900432CC8 /* BandMateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 268BF952286EACC900432CC8 /* BandMateTests.m */; };
 		268BF95D286EACCA00432CC8 /* BandMateUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 268BF95C286EACCA00432CC8 /* BandMateUITests.m */; };
 		268BF95F286EACCA00432CC8 /* BandMateUITestsLaunchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 268BF95E286EACCA00432CC8 /* BandMateUITestsLaunchTests.m */; };
+		26B782BD287CEB49004B0ADC /* MatchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 26B782BC287CEB49004B0ADC /* MatchViewController.m */; };
+		26B782C1287DE607004B0ADC /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 26B782C0287DE607004B0ADC /* Keys.plist */; };
 		5C72A3C66FC5E586513329F1 /* Pods_BandMateTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7A9C3377856E079D48F0EA7 /* Pods_BandMateTests.framework */; };
 		C4FF536DBC51E249F46D9CE2 /* Pods_BandMate_BandMateUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F0A01756A7A60FC84ED7C4D /* Pods_BandMate_BandMateUITests.framework */; };
 		D6930D9DF78C1EB3950B33B9 /* Pods_BandMate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28848E6C1F75558C0A4E7223 /* Pods_BandMate.framework */; };
@@ -67,6 +69,9 @@
 		268BF958286EACC900432CC8 /* BandMateUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BandMateUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		268BF95C286EACCA00432CC8 /* BandMateUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BandMateUITests.m; sourceTree = "<group>"; };
 		268BF95E286EACCA00432CC8 /* BandMateUITestsLaunchTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BandMateUITestsLaunchTests.m; sourceTree = "<group>"; };
+		26B782BB287CEB49004B0ADC /* MatchViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MatchViewController.h; sourceTree = "<group>"; };
+		26B782BC287CEB49004B0ADC /* MatchViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MatchViewController.m; sourceTree = "<group>"; };
+		26B782C0287DE607004B0ADC /* Keys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Keys.plist; sourceTree = "<group>"; };
 		28848E6C1F75558C0A4E7223 /* Pods_BandMate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BandMate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C64F94841F4852B272F0DEE /* Pods-BandMate-BandMateUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BandMate-BandMateUITests.release.xcconfig"; path = "Target Support Files/Pods-BandMate-BandMateUITests/Pods-BandMate-BandMateUITests.release.xcconfig"; sourceTree = "<group>"; };
 		5163B7A8B0C4F4FC41874437 /* Pods-BandMateTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BandMateTests.release.xcconfig"; path = "Target Support Files/Pods-BandMateTests/Pods-BandMateTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -157,6 +162,7 @@
 		268BF935286EACC900432CC8 /* BandMate */ = {
 			isa = PBXGroup;
 			children = (
+				26B782BA287CEB2B004B0ADC /* MatchViewController */,
 				263F2C902877562200A28601 /* ProfileViewController */,
 				263F2C892876558800A28601 /* RegisterViewController */,
 				263F2C882876557100A28601 /* LoginViewController */,
@@ -170,6 +176,7 @@
 				268BF942286EACC900432CC8 /* Assets.xcassets */,
 				268BF944286EACC900432CC8 /* LaunchScreen.storyboard */,
 				268BF947286EACC900432CC8 /* Info.plist */,
+				26B782C0287DE607004B0ADC /* Keys.plist */,
 				268BF948286EACC900432CC8 /* main.m */,
 			);
 			path = BandMate;
@@ -190,6 +197,15 @@
 				268BF95E286EACCA00432CC8 /* BandMateUITestsLaunchTests.m */,
 			);
 			path = BandMateUITests;
+			sourceTree = "<group>";
+		};
+		26B782BA287CEB2B004B0ADC /* MatchViewController */ = {
+			isa = PBXGroup;
+			children = (
+				26B782BB287CEB49004B0ADC /* MatchViewController.h */,
+				26B782BC287CEB49004B0ADC /* MatchViewController.m */,
+			);
+			path = MatchViewController;
 			sourceTree = "<group>";
 		};
 		B8B117D2911EF6703A8C9DDC /* Frameworks */ = {
@@ -323,6 +339,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				26B782C1287DE607004B0ADC /* Keys.plist in Resources */,
 				268BF946286EACC900432CC8 /* LaunchScreen.storyboard in Resources */,
 				268BF943286EACC900432CC8 /* Assets.xcassets in Resources */,
 				268BF941286EACC900432CC8 /* Main.storyboard in Resources */,
@@ -457,6 +474,7 @@
 				263F2C8F287655A800A28601 /* RegisterViewController.m in Sources */,
 				268BF938286EACC900432CC8 /* AppDelegate.m in Sources */,
 				268BF949286EACC900432CC8 /* main.m in Sources */,
+				26B782BD287CEB49004B0ADC /* MatchViewController.m in Sources */,
 				263F2C932877564C00A28601 /* ProfileViewController.m in Sources */,
 				268BF93B286EACC900432CC8 /* SceneDelegate.m in Sources */,
 				263F2C8C2876559D00A28601 /* LoginViewController.m in Sources */,

--- a/BandMate/AppDelegate.h
+++ b/BandMate/AppDelegate.h
@@ -6,9 +6,8 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "AppAuth.h"
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
-
-
+@property(nonatomic, strong, nullable) id<OIDExternalUserAgentSession> currentAuthorizationFlow;
 @end
-

--- a/BandMate/Base.lproj/Main.storyboard
+++ b/BandMate/Base.lproj/Main.storyboard
@@ -90,21 +90,64 @@
             </objects>
             <point key="canvasLocation" x="800" y="107"/>
         </scene>
-        <!--View Controller-->
+        <!--Match View Controller-->
         <scene sceneID="Lor-9j-whM">
             <objects>
-                <viewController id="Rhp-Ss-zV7" sceneMemberID="viewController">
+                <viewController id="Rhp-Ss-zV7" customClass="MatchViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="df4-As-O4J">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wlf-Jx-IuR">
+                                <rect key="frame" x="106" y="216" width="178" height="82"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="gray" title="Connect Spotify">
+                                    <color key="baseBackgroundColor" systemColor="systemGreenColor"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="didTapConnect:" destination="Rhp-Ss-zV7" eventType="touchUpInside" id="XH3-SR-IPB"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rkV-um-egU">
+                                <rect key="frame" x="106" y="329" width="178" height="82"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="gray" title="Disconnect Spotify">
+                                    <color key="baseBackgroundColor" systemColor="systemRedColor"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="didTapDisconnect:" destination="Rhp-Ss-zV7" eventType="touchUpInside" id="LUN-d7-kJ4"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PNj-9c-7Qr">
+                                <rect key="frame" x="106" y="454" width="178" height="82"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="gray" title="API Call">
+                                    <color key="baseBackgroundColor" systemColor="systemBlueColor"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="didTapApiCall:" destination="Rhp-Ss-zV7" eventType="touchUpInside" id="4tN-jJ-eRP"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="S83-8O-gnZ"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" id="pHx-rF-pFf"/>
+                    <connections>
+                        <outlet property="apiCallButton" destination="PNj-9c-7Qr" id="Z1z-Sr-Ycm"/>
+                        <outlet property="connectButton" destination="wlf-Jx-IuR" id="R6P-gA-YOU"/>
+                        <outlet property="disconnectButton" destination="rkV-um-egU" id="haj-It-dPa"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PmB-VI-gLM" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="797" y="1564"/>
+            <point key="canvasLocation" x="796.92307692307691" y="1563.9810426540284"/>
         </scene>
         <!--Match-->
         <scene sceneID="dUM-WC-6UB">
@@ -154,7 +197,7 @@
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="gray" title="Logout">
-                                    <color key="baseBackgroundColor" name="AccentColor"/>
+                                    <color key="baseBackgroundColor" systemColor="systemRedColor"/>
                                 </buttonConfiguration>
                                 <connections>
                                     <action selector="didTapLogout:" destination="zgC-XC-E7l" eventType="touchUpInside" id="Ac2-TO-Cyj"/>
@@ -347,14 +390,20 @@
         <image name="guitars" catalog="system" width="128" height="100"/>
         <image name="magnifyingglass" catalog="system" width="128" height="115"/>
         <image name="person.fill" catalog="system" width="128" height="120"/>
-        <namedColor name="AccentColor">
-            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <systemColor name="linkColor">
             <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGreenColor">
+            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/BandMate/Info.plist
+++ b/BandMate/Info.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>app.bandmate</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/BandMate/MatchViewController/MatchViewController.h
+++ b/BandMate/MatchViewController/MatchViewController.h
@@ -1,0 +1,16 @@
+//
+//  MatchViewController.h
+//  BandMate
+//
+//  Created by Jose Castillo Guajardo on 7/11/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MatchViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BandMate/MatchViewController/MatchViewController.m
+++ b/BandMate/MatchViewController/MatchViewController.m
@@ -1,0 +1,171 @@
+//
+//  MatchViewController.m
+//  BandMate
+//
+//  Created by Jose Castillo Guajardo on 7/11/22.
+//
+
+#import "MatchViewController.h"
+#import "AppAuth.h"
+#import "AppDelegate.h"
+
+// Spotify OAuth 2.0 configuration
+static NSString *kClientID;
+static NSString *const kIssuer = @"https://accounts.spotify.com/";
+static NSString *const kRedirectStringURI = @"app.bandmate:/callback";
+static NSString *const kAppAuthBandMateStateKey = @"authState";
+static NSString *const scope = @"user-top-read";
+
+@interface MatchViewController ()
+@property (weak, nonatomic) IBOutlet UIButton *connectButton;
+@property (weak, nonatomic) IBOutlet UIButton *disconnectButton;
+@property (weak, nonatomic) IBOutlet UIButton *apiCallButton;
+@property(strong, nonatomic, nullable) OIDAuthState *authState;
+@end
+
+@implementation MatchViewController
+
+- (void)viewDidLoad {
+    
+    [super viewDidLoad];
+
+    [self setup];
+
+}
+
+- (void)setup {
+    
+    NSString *path = [[NSBundle mainBundle] pathForResource: @"Keys" ofType: @"plist"];
+    NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile: path];
+
+    kClientID = [dict objectForKey: @"client_ID"];
+    
+    [self loadState];
+    
+    if (self.authState) {
+        self.connectButton.enabled = NO;
+    } else {
+        self.disconnectButton.enabled = NO;
+        self.apiCallButton.enabled = NO;
+    }
+    
+}
+
+// Temporary buttons for testing
+- (IBAction)didTapConnect:(id)sender {
+    [self performOAuth];
+}
+
+- (IBAction)didTapDisconnect:(id)sender {
+    [self deleteState];
+}
+
+- (IBAction)didTapApiCall:(id)sender {
+    [self getTopArtists];
+}
+
+// Performs Spotify OAuth 2.0
+- (void)performOAuth {
+    
+    NSURL *issuer = [NSURL URLWithString:kIssuer];
+    NSURL *kRedirectURI = [NSURL URLWithString:kRedirectStringURI];
+    
+    [OIDAuthorizationService discoverServiceConfigurationForIssuer:issuer completion:^(OIDServiceConfiguration * _Nullable configuration, NSError * _Nullable error) {
+        
+        if (!configuration) {
+            NSLog(@"Error retrieving discovery document: %@", [error localizedDescription]);
+            return;
+        }
+        
+        // Build authentication request
+        OIDAuthorizationRequest *request =
+        [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
+                                                      clientId:kClientID
+                                                        scopes:@[scope]
+                                                   redirectURL:kRedirectURI
+                                                  responseType:OIDResponseTypeCode
+                                          additionalParameters:nil];
+        
+        // Makes authentication request
+        AppDelegate *appDelegate = (AppDelegate *)[UIApplication sharedApplication].delegate;
+        appDelegate.currentAuthorizationFlow = [OIDAuthState authStateByPresentingAuthorizationRequest:request presentingViewController:self callback:^(OIDAuthState * _Nullable authState, NSError * _Nullable error) {
+            if (authState) {
+                NSLog(@"Got authorization tokes. Access tokes: %@", authState.lastTokenResponse.accessToken);
+                [self setAuthState:authState];
+                [self saveState];
+                self.connectButton.enabled = NO;
+                self.disconnectButton.enabled = YES;
+                self.apiCallButton.enabled = YES;
+            } else {
+                NSLog(@"Authorization error: %@", [error localizedDescription]);
+                [self setAuthState:nil];
+            }
+        }];
+        
+    }];
+    
+}
+
+// Stores OIDAuthState state in NSUserdefaults
+- (void)saveState {
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"bandmate.authState"];
+  NSData *archivedAuthState = [NSKeyedArchiver archivedDataWithRootObject:_authState];
+  [userDefaults setObject:archivedAuthState
+                   forKey:kAppAuthBandMateStateKey];
+  [userDefaults synchronize];
+}
+
+// Loads OIDAuthState from NSUSerDefaults
+- (void)loadState {
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"bandmate.authState"];
+  NSData *archivedAuthState = [userDefaults objectForKey:kAppAuthBandMateStateKey];
+  OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
+  [self setAuthState:authState];
+}
+
+// Deletes OIDAuthState when logout of Spotify
+-(void)deleteState {
+    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"bandmate.authState"];
+    [userDefaults removeObjectForKey:kAppAuthBandMateStateKey];
+    [userDefaults synchronize];
+    [self setAuthState:nil];
+    self.connectButton.enabled = YES;
+    self.disconnectButton.enabled = NO;
+    self.apiCallButton.enabled = NO;
+}
+
+// API call always with fresh OAuth 2.0 tokens
+- (void)getTopArtists {
+
+    [self.authState performActionWithFreshTokens:^(NSString * _Nullable accessToken, NSString * _Nullable idToken, NSError * _Nullable error) {
+        
+        if (error != nil) {
+            NSLog(@"Error: %@", [error localizedDescription]);
+        } else {
+            NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
+            
+            NSString *token = @"Bearer ";
+            NSString *authHeader = [token stringByAppendingString:accessToken];
+            
+            [request setURL:[NSURL URLWithString:@"https://api.spotify.com/v1/me/top/artists"]];
+            [request setHTTPMethod:@"GET"];
+            [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+            [request setValue:authHeader forHTTPHeaderField:@"Authorization"];
+            
+            NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+            
+            [[session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                if (error) {
+                    NSLog(@"Error: %@", [error localizedDescription]);
+                }
+                NSString *requestReply = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
+                NSLog(@"Request reply: %@", requestReply);
+
+            }] resume];
+        }
+        
+    }];
+    
+}
+
+@end


### PR DESCRIPTION
This PR includes the integration of the Spotify Web API with the app. First authentication with OAuth 2.0 was done to get an access token. With the access token API calls can be made.

To test the integration I added three temporary buttons. In the demo is shown how a user links Spotify account with the app and makes an API call, which returns user's top artists.

https://user-images.githubusercontent.com/69658875/178610107-64b93aeb-43c3-4f3e-9932-dbb0359e751b.mov


