### PR TITLE
Added Data Model for Artist & saves artists to database

### DIFF
--- a/BandMate.xcodeproj/project.pbxproj
+++ b/BandMate.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		263CC3BA287F29E0002941BB /* Artist.m in Sources */ = {isa = PBXBuildFile; fileRef = 263CC3B9287F29E0002941BB /* Artist.m */; };
 		263F2C8C2876559D00A28601 /* LoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 263F2C8B2876559D00A28601 /* LoginViewController.m */; };
 		263F2C8F287655A800A28601 /* RegisterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 263F2C8E287655A800A28601 /* RegisterViewController.m */; };
 		263F2C932877564C00A28601 /* ProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 263F2C922877564C00A28601 /* ProfileViewController.m */; };
@@ -46,6 +47,8 @@
 
 /* Begin PBXFileReference section */
 		1F0A01756A7A60FC84ED7C4D /* Pods_BandMate_BandMateUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BandMate_BandMateUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		263CC3B8287F29E0002941BB /* Artist.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Artist.h; sourceTree = "<group>"; };
+		263CC3B9287F29E0002941BB /* Artist.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Artist.m; sourceTree = "<group>"; };
 		263F2C8A2876559D00A28601 /* LoginViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoginViewController.h; sourceTree = "<group>"; };
 		263F2C8B2876559D00A28601 /* LoginViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LoginViewController.m; sourceTree = "<group>"; };
 		263F2C8D287655A800A28601 /* RegisterViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegisterViewController.h; sourceTree = "<group>"; };
@@ -110,6 +113,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		263CC3B7287F29BC002941BB /* DataModels */ = {
+			isa = PBXGroup;
+			children = (
+				263CC3B8287F29E0002941BB /* Artist.h */,
+				263CC3B9287F29E0002941BB /* Artist.m */,
+			);
+			path = DataModels;
+			sourceTree = "<group>";
+		};
 		263F2C882876557100A28601 /* LoginViewController */ = {
 			isa = PBXGroup;
 			children = (
@@ -162,6 +174,7 @@
 		268BF935286EACC900432CC8 /* BandMate */ = {
 			isa = PBXGroup;
 			children = (
+				263CC3B7287F29BC002941BB /* DataModels */,
 				26B782BA287CEB2B004B0ADC /* MatchViewController */,
 				263F2C902877562200A28601 /* ProfileViewController */,
 				263F2C892876558800A28601 /* RegisterViewController */,
@@ -477,6 +490,7 @@
 				26B782BD287CEB49004B0ADC /* MatchViewController.m in Sources */,
 				263F2C932877564C00A28601 /* ProfileViewController.m in Sources */,
 				268BF93B286EACC900432CC8 /* SceneDelegate.m in Sources */,
+				263CC3BA287F29E0002941BB /* Artist.m in Sources */,
 				263F2C8C2876559D00A28601 /* LoginViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BandMate/DataModels/Artist.h
+++ b/BandMate/DataModels/Artist.h
@@ -1,0 +1,32 @@
+//
+//  Artist.h
+//  BandMate
+//
+//  Created by Jose Castillo Guajardo on 7/13/22.
+//
+
+#import <Parse/Parse.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Artist : PFObject<PFSubclassing>
+
+// Properties
+
+@property (nonatomic, strong) NSString *artistID;
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic, strong) NSString *uri;
+@property (nonatomic, strong) NSArray *genres;
+@property (nonatomic, strong) NSArray *images;
+@property (nonatomic, strong) NSArray *externalURL;
+@property (nonatomic, strong) NSNumber *followers;
+
+// Methods
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
++ (NSArray *)artistsWithArray:(NSArray *)dictionaries;
++ (NSArray *)userGenresWithArray:(NSArray *)artistObjects;
++ (NSArray *)userArtistIDsWithArray:(NSArray *)artistObjects;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BandMate/DataModels/Artist.m
+++ b/BandMate/DataModels/Artist.m
@@ -1,0 +1,79 @@
+//
+//  Artist.m
+//  BandMate
+//
+//  Created by Jose Castillo Guajardo on 7/13/22.
+//
+
+#import "Artist.h"
+
+@implementation Artist
+
+@dynamic artistID;
+@dynamic name;
+@dynamic uri;
+@dynamic genres;
+@dynamic images;
+@dynamic externalURL;
+@dynamic followers;
+
++ (nonnull NSString *)parseClassName {
+    return @"Artist";
+}
+
+-(instancetype)initWithDictionary:(NSDictionary *)dictionary {
+    
+    self = [super init];
+    
+    self.artistID = dictionary[@"id"];
+    self.name = dictionary[@"name"];
+    self.uri = dictionary[@"uri"];
+    self.genres = dictionary[@"genres"];
+    self.images = dictionary[@"images"];
+    self.externalURL = dictionary[@"external_urls"];
+    self.followers = [dictionary valueForKeyPath:@"followers.total"];
+    return self;
+    
+}
+
++(NSArray *)artistsWithArray:(NSArray *)dictionaries {
+    
+    NSMutableArray *artists = [NSMutableArray array];
+    
+    for (NSDictionary *dictionary in dictionaries) {
+        Artist *artist = [[Artist alloc] initWithDictionary:dictionary];
+        [artists addObject:artist];
+    }
+    
+    return artists;
+    
+}
+
++ (NSArray *)userGenresWithArray:(NSArray *)artistObjects {
+    
+    NSMutableArray *arrayOfGenres = [NSMutableArray array];
+    
+    for (Artist *artist in artistObjects) {
+        [arrayOfGenres addObjectsFromArray:artist.genres];
+    }
+    
+    NSOrderedSet *orderedSet = [NSOrderedSet orderedSetWithArray:arrayOfGenres];
+    NSArray *arrayWithoutDuplicates = [orderedSet array];
+    
+    return arrayWithoutDuplicates;
+    
+}
+
++ (NSArray *)userArtistIDsWithArray:(NSArray *)artistObjects {
+    
+    NSMutableArray *arrayOfArtistID = [NSMutableArray array];
+    
+    for (Artist *artist in artistObjects) {
+        [arrayOfArtistID addObject:artist.artistID];
+    }
+    
+    return arrayOfArtistID;
+    
+}
+
+@end


### PR DESCRIPTION
This PR consists of the development of Artist data model/class. The class is used to handle the data  that is retrieved from Spotify API in an efficient way. The Artist objects are saved to the DB for future access, they will be used later in the app.

<img width="2124" alt="Screen Shot 2022-07-13 at 4 25 21 PM" src="https://user-images.githubusercontent.com/69658875/178854208-484c41f4-5047-45d8-854b-a12b9484b173.png">

Also each user now has a fav_artists and fav_genres property, which will be used to make the matching algorithm. 
The fav_artists and fav_genres properties are saved successfully to the database as shown in the screenshot below.

<img width="2539" alt="Screen Shot 2022-07-13 at 4 24 50 PM" src="https://user-images.githubusercontent.com/69658875/178854198-47696574-da0c-42d7-8ba2-007ef5df7ae3.png">